### PR TITLE
E-groups cleaning and minor warning fixes

### DIFF
--- a/app.js
+++ b/app.js
@@ -146,8 +146,7 @@ app.all('*', isUserAuthenticated, (req, res) => {
     res.setTimeout(500000);
     const { user } = req;
     if (user) {
-      // user.egroups = clean_egroups( user.egroups );
-      user.egroups = user.egroups + user.egroups + user.egroups;
+      user.egroups = clean_egroups( user.egroups );
       
       proxyReq.setHeader('displayname', user.displayname);
       proxyReq.setHeader('egroups', user.egroups);

--- a/app.js
+++ b/app.js
@@ -144,10 +144,10 @@ app.all('*', isUserAuthenticated, (req, res) => {
       if( process.env.enviroment == "dev" ){
         var timestamp = '[' + (new Date()).toLocaleString() + '] ';
         console.log( timestamp );
-        console.log( req.displayname );
-        console.log( req.email );
-        console.log( req.egroups );
-        console.log( req.id );
+        console.log( user.displayname );
+        console.log( user.email );
+        console.log( user.egroups );
+        console.log( user.id );
       };
     }
   });

--- a/app.js
+++ b/app.js
@@ -131,15 +131,6 @@ if (process.env.API_URL) {
 
 // Client requests
 app.all('*', isUserAuthenticated, (req, res) => {
-  if( process.env.enviroment == "dev" ){
-    var timestamp = '[' + Date.now() + '] ';
-    console.log( timestamp );
-    console.log( req.displayname );
-    console.log( req.email );
-    console.log( req.egroups );
-    console.log( req.id );
-  };
-
   proxy.on('proxyReq', (proxyReq, req, res, options) => {
     req.setTimeout(500000);
     res.setTimeout(500000);
@@ -149,6 +140,15 @@ app.all('*', isUserAuthenticated, (req, res) => {
       proxyReq.setHeader('egroups', user.egroups);
       proxyReq.setHeader('email', user.email);
       proxyReq.setHeader('id', user.id);
+      
+      if( process.env.enviroment == "dev" ){
+        var timestamp = '[' + (new Date()).toLocaleString() + '] ';
+        console.log( timestamp );
+        console.log( req.displayname );
+        console.log( req.email );
+        console.log( req.egroups );
+        console.log( req.id );
+      };
     }
   });
 

--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ const httpProxy = require('http-proxy');
 const bodyParser = require('body-parser');
 const cookieParser = require('cookie-parser');
 const session = require('express-session');
+const MemoryStore = require('memorystore')(session)
 const port = 8080;
 
 const long_timeout = 2147483640;
@@ -28,7 +29,11 @@ server.on('upgrade', function (req, res, head) {
 });
 
 app.use(cookieParser());
-app.use(session({ secret: 'cern' }));
+app.use(session({ secret: 'cern', resave: true, saveUninitialized: true, 
+                 store: new MemoryStore({ 
+                   checkPeriod: 86400000 // prune expired entries every 24h
+                                        }), 
+                }));
 
 // USE OF BODY PARSER will make proxying of API unusuable (for POST and PUT): see https://github.com/chimurai/http-proxy-middleware/issues/299
 // app.use(bodyParser.json());
@@ -129,11 +134,14 @@ if (process.env.API_URL) {
   });
 }
 
+// keep only relevant groups
+// https://twiki.cern.ch/twiki/bin/view/CMS/DQMRunRegistry2018#Authentication
 function clean_egroups( egroups ){
   var egroups_answer = "";
   all_egroups = egroups.split(';');
   all_egroups.forEach( function (item, index) {
     if( item.includes("dqm") ) egroups_answer += item + ";"
+    if( item.includes("DQM") ) egroups_answer += item + ";"
   });
   if( egroups_answer.length ) egroups_answer = egroups_answer.slice(0, -1)
   return( egroups_answer )
@@ -153,14 +161,15 @@ app.all('*', isUserAuthenticated, (req, res) => {
       proxyReq.setHeader('email', user.email);
       proxyReq.setHeader('id', user.id);
       
-      if( process.env.enviroment == "dev" ){
-        var timestamp = '[' + (new Date()).toLocaleString() + '] ';
-        console.log( timestamp );
-        console.log( user.displayname );
-        console.log( user.email );
-        console.log( user.egroups );
-        console.log( user.id );
-      };
+      // uncomment following for some logs printout 
+      //if( process.env.enviroment == "dev"  ){
+      //  var timestamp = '[' + (new Date()).toLocaleString() + '] ';
+      //  console.log( timestamp );
+      //  console.log( user.displayname );
+      //  console.log( user.email );
+      //  console.log( user.egroups );
+      //  console.log( user.id );
+      //};
     }
   });
 
@@ -171,7 +180,9 @@ app.all('*', isUserAuthenticated, (req, res) => {
 
 // If something goes wrong on either API or client:
 proxy.on('error', function (err, req, res) {
-  console.log(err);
+  var timestamp = '[' + (new Date()).toLocaleString() + '] ';
+  console.log( timestamp );
+  console.log( err );
   try {
     res.writeHead(500, {
       'Content-Type': 'text/plain',

--- a/app.js
+++ b/app.js
@@ -134,10 +134,10 @@ app.all('*', isUserAuthenticated, (req, res) => {
   if( process.env.enviroment == "dev" ){
     var timestamp = '[' + Date.now() + '] ';
     console.log( timestamp );
-    console.log( user.displayname );
-    console.log( user.email );
-    console.log( user.egroups );
-    console.log( user.id );
+    console.log( req.displayname );
+    console.log( req.email );
+    console.log( req.egroups );
+    console.log( req.id );
   };
 
   proxy.on('proxyReq', (proxyReq, req, res, options) => {
@@ -145,10 +145,10 @@ app.all('*', isUserAuthenticated, (req, res) => {
     res.setTimeout(500000);
     const { user } = req;
     if (user) {
-      proxyReq.setHeader('displayname', req.displayname);
-      proxyReq.setHeader('egroups', req.egroups);
-      proxyReq.setHeader('email', req.email);
-      proxyReq.setHeader('id', req.id);
+      proxyReq.setHeader('displayname', user.displayname);
+      proxyReq.setHeader('egroups', user.egroups);
+      proxyReq.setHeader('email', user.email);
+      proxyReq.setHeader('id', user.id);
     }
   });
 

--- a/app.js
+++ b/app.js
@@ -145,10 +145,10 @@ app.all('*', isUserAuthenticated, (req, res) => {
     res.setTimeout(500000);
     const { user } = req;
     if (user) {
-      proxyReq.setHeader('displayname', user.displayname);
-      proxyReq.setHeader('egroups', user.egroups);
-      proxyReq.setHeader('email', user.email);
-      proxyReq.setHeader('id', user.id);
+      proxyReq.setHeader('displayname', req.displayname);
+      proxyReq.setHeader('egroups', req.egroups);
+      proxyReq.setHeader('email', req.email);
+      proxyReq.setHeader('id', req.id);
     }
   });
 

--- a/app.js
+++ b/app.js
@@ -129,6 +129,16 @@ if (process.env.API_URL) {
   });
 }
 
+function clean_egroups( egroups ){
+  var egroups_answer = "";
+  all_egroups = egroups.split(';');
+  all_egroups.forEach( function (item, index) {
+    if( item.includes("dqm") ) egroups_answer += item + ";"
+  });
+  if( egroups_answer.length ) egroups_answer = egroups_answer.slice(0, -1)
+  return( egroups_answer )
+};
+
 // Client requests
 app.all('*', isUserAuthenticated, (req, res) => {
   proxy.on('proxyReq', (proxyReq, req, res, options) => {
@@ -136,6 +146,9 @@ app.all('*', isUserAuthenticated, (req, res) => {
     res.setTimeout(500000);
     const { user } = req;
     if (user) {
+      // user.egroups = clean_egroups( user.egroups );
+      user.egroups = user.egroups + user.egroups + user.egroups;
+      
       proxyReq.setHeader('displayname', user.displayname);
       proxyReq.setHeader('egroups', user.egroups);
       proxyReq.setHeader('email', user.email);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "cookie-parser": "^1.4.3",
         "express": "^4.16.4",
         "express-session": "^1.15.6",
+        "memorystore" : "^1.6.7",
         "http-proxy": "^1.17.0",
         "passport": "^0.4.0",
         "passport-oauth2": "^1.4.0"


### PR DESCRIPTION
1. remove e-groups without "dqm" substring from request header - people with lot of e-groups are not able to access RR because of "headers too long" error (reported by Javier).
2. fix saveUninitialized & resave warning to be "true" instead of default outdated value.
3. fix MemoryStore warning adding store option which could be used in production.
4.  update package.json https://stackoverflow.com/questions/45052520/do-i-need-both-package-lock-json-and-package-json.